### PR TITLE
Return a Result from sandbox_this_process()

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use rusty_sandbox::Sandbox;
 
 fn main() {
     let mut file = fs::File::open("README.md").unwrap();
-    Sandbox::new().sandbox_this_process();
+    Sandbox::new().sandbox_this_process().expect("Couldn't enter sandbox");
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).unwrap();
     println!("Read file: {}", String::from_utf8_lossy(&buf));
@@ -91,7 +91,8 @@ use rusty_sandbox::Sandbox;
 fn main() {
     let ctx = Sandbox::new()
         .add_directory("repo", ".")
-        .sandbox_this_process();
+        .sandbox_this_process()
+        .unwrap();
     let mut file = ctx.directory("repo").unwrap()
         .open_options().open("README.md").unwrap();
     let mut buf = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,12 @@ impl Sandbox {
         self
     }
 
-    pub fn sandbox_this_process(&self) -> SandboxContext {
-        platform::enter_sandbox(Box::new(self.dirs.values()));
-        self.context()
+    pub fn sandbox_this_process(&self) -> Result<SandboxContext, ()> {
+        if platform::enter_sandbox(Box::new(self.dirs.values())) {
+            Ok(self.context())
+        } else {
+            Err(())
+        }
     }
 
     pub fn sandboxed_fork<F>(&self, fun: F) -> io::Result<RunningSandbox>


### PR DESCRIPTION
This changes the return type of `sandbox_this_process()` to `Result<SandboxContext, ()>` so it's possible for applications to determine if they've successfully entered a sandbox.